### PR TITLE
Remove localhost link

### DIFF
--- a/about.md
+++ b/about.md
@@ -40,7 +40,7 @@ I am a third year Ph.D. (EE) student working with [Prof. Jarvis Haupt](http://ww
  </li>
 <li> <strong> Target-Based Hyperspectral Demixing via Generalized Robust PCA. </strong>[<i>preprint coming soon</i>]  <br> S. Rambhatla, X. Li and J. Haupt. <br> <em> 2017 IEEE Asilomar Conference on Signals, Systems and Computers. </em> [<i>accepted</i>] <br>
   &#127942; <em style="color:#AAA;"> Finalist, Student Best Paper Award (TBD at the conference)</em> <br>
-[<a href="http://127.0.0.1:4444/grpca/2017/05/11/HyperSpectral.html">Demo</a>]
+[<a href="/grpca/2017/05/11/HyperSpectral.html">Demo</a>]
 
  </li>
 <li> <a href="http://ieeexplore.ieee.org/document/7906054/">A Dictionary Based Generalization of Robust PCA. </a>   <br> S. Rambhatla, X. Li and J. Haupt. <br> <em> 2016 IEEE Global Conference on Signal and Information Processing </em> <br>


### PR DESCRIPTION
localhost link found under "Target-Based Hyperspectral Demixing via Generalized Robust PCA" on About page, this PR removes it.